### PR TITLE
feat: API 공통 응답, 예외 처리 기능 추가

### DIFF
--- a/module-common/src/main/java/com/fashionmall/common/exception/CustomException.java
+++ b/module-common/src/main/java/com/fashionmall/common/exception/CustomException.java
@@ -1,14 +1,13 @@
 package com.fashionmall.common.exception;
 
-import com.fashionmall.common.response.CustomResponseCode;
 import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
 
-    private final CustomResponseCode code;
+    private final ErrorResponseCode code;
 
-    public CustomException(CustomResponseCode code) {
+    public CustomException(ErrorResponseCode code) {
         this.code = code;
     }
 }

--- a/module-common/src/main/java/com/fashionmall/common/exception/CustomException.java
+++ b/module-common/src/main/java/com/fashionmall/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.fashionmall.common.exception;
+
+import com.fashionmall.common.response.CustomResponseCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final CustomResponseCode code;
+
+    public CustomException(CustomResponseCode code) {
+        this.code = code;
+    }
+}

--- a/module-common/src/main/java/com/fashionmall/common/exception/ErrorResponseCode.java
+++ b/module-common/src/main/java/com/fashionmall/common/exception/ErrorResponseCode.java
@@ -1,4 +1,4 @@
-package com.fashionmall.common.response;
+package com.fashionmall.common.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum CustomResponseCode {
+public enum ErrorResponseCode {
 
     //공통 코드
     SUCCESS(HttpStatus.OK, "성공"),

--- a/module-common/src/main/java/com/fashionmall/common/exception/ErrorResponseCode.java
+++ b/module-common/src/main/java/com/fashionmall/common/exception/ErrorResponseCode.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorResponseCode {
 
     //공통 코드
-    SUCCESS(HttpStatus.OK, "성공"),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "필수 값을 입력해 주세요"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다"),

--- a/module-common/src/main/java/com/fashionmall/common/exception/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/com/fashionmall/common/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.fashionmall.common.exception.handler;
+
+import com.fashionmall.common.exception.CustomException;
+import com.fashionmall.common.response.CommonResponse;
+import com.fashionmall.common.response.CustomResponseCode;
+import com.fashionmall.common.util.ApiResponseUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(value = Exception.class)
+    protected ResponseEntity<CommonResponse<Object>> handleException(Exception e) {
+        log.error("Exception", e);
+        return toErrrorResponseEntity(CustomResponseCode.SERVER_ERROR);
+    }
+
+    @ExceptionHandler(value = CustomException.class)
+    protected ResponseEntity<CommonResponse<Object>> handleCustomException(CustomException e) {
+        log.warn("CustomException", e);
+        return toErrrorResponseEntity(e.getCode());
+    }
+
+    protected ResponseEntity<CommonResponse<Object>> toErrrorResponseEntity(CustomResponseCode customResponseCode) {
+        return ResponseEntity
+                .status(customResponseCode.getStatus())
+                .body(ApiResponseUtil.failure(customResponseCode));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception exception, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        log.error("Exception", exception);
+        CommonResponse<Object> response = ApiResponseUtil.failure(statusCode.value(), exception.getMessage());
+        return ResponseEntity.status(statusCode).body(response);
+    }
+}

--- a/module-common/src/main/java/com/fashionmall/common/exception/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/com/fashionmall/common/exception/handler/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package com.fashionmall.common.exception.handler;
 
 import com.fashionmall.common.exception.CustomException;
 import com.fashionmall.common.response.CommonResponse;
-import com.fashionmall.common.response.CustomResponseCode;
+import com.fashionmall.common.exception.ErrorResponseCode;
 import com.fashionmall.common.util.ApiResponseUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -20,7 +20,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = Exception.class)
     protected ResponseEntity<CommonResponse<Object>> handleException(Exception e) {
         log.error("Exception", e);
-        return toErrrorResponseEntity(CustomResponseCode.SERVER_ERROR);
+        return toErrrorResponseEntity(ErrorResponseCode.SERVER_ERROR);
     }
 
     @ExceptionHandler(value = CustomException.class)
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return toErrrorResponseEntity(e.getCode());
     }
 
-    protected ResponseEntity<CommonResponse<Object>> toErrrorResponseEntity(CustomResponseCode customResponseCode) {
+    protected ResponseEntity<CommonResponse<Object>> toErrrorResponseEntity(ErrorResponseCode customResponseCode) {
         return ResponseEntity
                 .status(customResponseCode.getStatus())
                 .body(ApiResponseUtil.failure(customResponseCode));

--- a/module-common/src/main/java/com/fashionmall/common/response/CommonResponse.java
+++ b/module-common/src/main/java/com/fashionmall/common/response/CommonResponse.java
@@ -1,0 +1,23 @@
+package com.fashionmall.common.response;
+
+import lombok.Getter;
+
+@Getter
+public class CommonResponse<T> {
+
+    private final Integer status;
+    private final String message;
+    private final T data;
+
+    public CommonResponse(Integer status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public CommonResponse(Integer status, String message) {
+        this.status = status;
+        this.message = message;
+        this.data = null;
+    }
+}

--- a/module-common/src/main/java/com/fashionmall/common/response/CustomResponseCode.java
+++ b/module-common/src/main/java/com/fashionmall/common/response/CustomResponseCode.java
@@ -1,0 +1,28 @@
+package com.fashionmall.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CustomResponseCode {
+
+    //공통 코드
+    SUCCESS(HttpStatus.OK, "성공"),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "필수 값을 입력해 주세요"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다"),
+    OUT_OF_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다"),
+    NOT_FOUND(HttpStatus.NOT_FOUND,"해당 요청을 찾을 수 없습니다"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+
+    //커스텀 코드
+    ORDER_NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "유효하지 않은 쿠폰입니다"),
+    ORDER_NOT_FOUND_BILLING_KEY(HttpStatus.NOT_FOUND, "유효하지 않은 결제 수단 입니다"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일 입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/module-common/src/main/java/com/fashionmall/common/util/ApiResponseUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/util/ApiResponseUtil.java
@@ -1,0 +1,25 @@
+package com.fashionmall.common.util;
+
+import com.fashionmall.common.response.CommonResponse;
+import com.fashionmall.common.response.CustomResponseCode;
+
+import static com.fashionmall.common.response.CustomResponseCode.*;
+
+public class ApiResponseUtil {
+
+    public static <T> CommonResponse<T> success(){
+        return new CommonResponse<>(SUCCESS.getStatus().value(), SUCCESS.getMessage(), null);
+    }
+
+    public static <T>CommonResponse<T> success(T data){
+        return new CommonResponse<>(SUCCESS.getStatus().value(), SUCCESS.getMessage(), data);
+    }
+
+    public static <T>CommonResponse<T> failure(CustomResponseCode errorCode) {
+        return new CommonResponse<>(errorCode.getStatus().value(), errorCode.getMessage());
+    }
+
+    public static <T>CommonResponse<T> failure(Integer statusCode, String message) {
+        return new CommonResponse<>(statusCode, message);
+    }
+}

--- a/module-common/src/main/java/com/fashionmall/common/util/ApiResponseUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/util/ApiResponseUtil.java
@@ -1,18 +1,20 @@
 package com.fashionmall.common.util;
 
-import com.fashionmall.common.response.CommonResponse;
 import com.fashionmall.common.exception.ErrorResponseCode;
-
-import static com.fashionmall.common.exception.ErrorResponseCode.*;
+import com.fashionmall.common.response.CommonResponse;
+import org.springframework.http.HttpStatus;
 
 public class ApiResponseUtil {
 
+    private static final Integer successStatus = HttpStatus.OK.value();
+    private static final String successMessage = "성공";
+
     public static <T> CommonResponse<T> success(){
-        return new CommonResponse<>(SUCCESS.getStatus().value(), SUCCESS.getMessage(), null);
+        return new CommonResponse<>(successStatus, successMessage, null);
     }
 
     public static <T>CommonResponse<T> success(T data){
-        return new CommonResponse<>(SUCCESS.getStatus().value(), SUCCESS.getMessage(), data);
+        return new CommonResponse<>(successStatus, successMessage, data);
     }
 
     public static <T>CommonResponse<T> failure(ErrorResponseCode errorCode) {

--- a/module-common/src/main/java/com/fashionmall/common/util/ApiResponseUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/util/ApiResponseUtil.java
@@ -1,9 +1,9 @@
 package com.fashionmall.common.util;
 
 import com.fashionmall.common.response.CommonResponse;
-import com.fashionmall.common.response.CustomResponseCode;
+import com.fashionmall.common.exception.ErrorResponseCode;
 
-import static com.fashionmall.common.response.CustomResponseCode.*;
+import static com.fashionmall.common.exception.ErrorResponseCode.*;
 
 public class ApiResponseUtil {
 
@@ -15,7 +15,7 @@ public class ApiResponseUtil {
         return new CommonResponse<>(SUCCESS.getStatus().value(), SUCCESS.getMessage(), data);
     }
 
-    public static <T>CommonResponse<T> failure(CustomResponseCode errorCode) {
+    public static <T>CommonResponse<T> failure(ErrorResponseCode errorCode) {
         return new CommonResponse<>(errorCode.getStatus().value(), errorCode.getMessage());
     }
 


### PR DESCRIPTION
## 📝작업 내용

- 공통 응답 코드 생성
응답 코드들을 모아둔 Enum클래스 생성, 정상값과 예외값이 합쳐있어 CustomResponseCode로 지음

- API 공통 응답 처리 기능 생성
응답객체클래스와 응답생성클래스로 분리해 생성

- API 공통 예외 처리 기능 생성
Exception.class와 RuntimeException을 상속받은 CustomException.class 예외처리

### 스크린샷

## 💬리뷰 요구사항

- CustomResponseCode에 추가하거나 삭제해야할 코드가 있다면 편하게 말씀해주시길 바랍니다.

## 🔗참고 링크

## ⏰기한

- 2024-09-10