### PR TITLE
feat : WebClientUtil 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ subprojects {
         annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
         annotationProcessor "jakarta.annotation:jakarta.annotation-api"
         annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+        //WebFlux 주입
+        implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+        //netty-resolver-dns-native-macos 의존성 주입
+        implementation 'io.netty:netty-resolver-dns-native-macos:4.1.113.Final:osx-aarch_64'
     }
 
     tasks.named('bootJar') {

--- a/module-common/src/main/java/com/fashionmall/common/config/AppConfig.java
+++ b/module-common/src/main/java/com/fashionmall/common/config/AppConfig.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @RequiredArgsConstructor
@@ -14,5 +15,10 @@ public class AppConfig {
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
         return new JPAQueryFactory(em);
+    }
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
     }
 }

--- a/module-common/src/main/java/com/fashionmall/common/util/WebClientUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/util/WebClientUtil.java
@@ -73,12 +73,13 @@ public class WebClientUtil {
     public <T> T delete(String uri, Class<T> responseType, Map<String, String> headers) {
         return webClient.delete()
                 .uri(uri)
+                .headers(getHttpHeadersConsumer(headers))
                 .retrieve()
                 .bodyToMono(responseType)
                 .block();
     }
 
-    private static Consumer<HttpHeaders> getHttpHeadersConsumer(Map<String, String> headers) {
+    private Consumer<HttpHeaders> getHttpHeadersConsumer(Map<String, String> headers) {
         return httpHeaders -> {
             if (headers != null) {
                 for (Map.Entry<String, String> entry : headers.entrySet()) {

--- a/module-common/src/main/java/com/fashionmall/common/util/WebClientUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/util/WebClientUtil.java
@@ -1,0 +1,94 @@
+package com.fashionmall.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+@Component
+@RequiredArgsConstructor
+public class WebClientUtil {
+
+    private final WebClient webClient;
+
+    public <T> T get(String uri, Class<T> responseType, Map<String, String> queryParam, Map<String, String> headers) {
+        return webClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder.path(uri);
+                    if (queryParam != null) {
+                        queryParam.forEach(uriBuilder::queryParam);
+                    }
+                    return uriBuilder.build();
+                })
+                .headers(getHttpHeadersConsumer(headers))
+                .retrieve()
+                .bodyToMono(responseType)
+                .block();
+    }
+
+    public <T> T post(String uri, Object requestBody, Class<T> responseType, Map<String, String> headers) {
+        return webClient.post()
+                .uri(uri)
+                .headers(getHttpHeadersConsumer(headers))
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(responseType)
+                .block();
+    }
+
+    public <T> T post(String uri, Object requestBody, ParameterizedTypeReference<T> elementTypeRef, Map<String, String> headers) {
+        return webClient.post()
+                .uri(uri)
+                .headers(getHttpHeadersConsumer(headers))
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(elementTypeRef)
+                .block();
+    }
+
+    public <T> T put(String uri, Object requestBody, Class<T> responseType, Map<String, String> headers) {
+        return webClient.put()
+                .uri(uri)
+                .headers(getHttpHeadersConsumer(headers))
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(responseType)
+                .block();
+    }
+
+    public <T> T patch(String uri, Object requestBody, Class<T> responseType, Map<String, String> headers) {
+        return webClient.patch()
+                .uri(uri)
+                .headers(getHttpHeadersConsumer(headers))
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(responseType)
+                .block();
+    }
+
+    public <T> T delete(String uri, Class<T> responseType, Map<String, String> headers) {
+        return webClient.delete()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(responseType)
+                .block();
+    }
+
+    private static Consumer<HttpHeaders> getHttpHeadersConsumer(Map<String, String> headers) {
+        return httpHeaders -> {
+            if (headers != null) {
+                for (Map.Entry<String, String> entry : headers.entrySet()) {
+                    httpHeaders.add(
+                            entry.getKey(),
+                            entry.getValue()
+                    );
+
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

- HTTP요청 라이브러리 WebClient 사용을 위해 WebFlux 주입
- WebClient 빈 주입
- WebClient의  Http메서드를 지원하는 WebClientUtil 클래스 구현
- 유틸 클래스의 각 메서드는 uri, 요청값, 응답 타입, 쿼리파라미터, 헤더 등을 받아서 사용할 수 있게 구현
- MacOs에서 발생하는 `Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider` 오류로 인해 Netty DNS Resolver 의존성 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## 🔗참고 링크(선택)

- 리뷰어가 참고할 링크(블로그 혹은 연관작업PR)가 있으면 작성해주세요

## ⏰기한

- 2024-09-25