### PR TITLE
feat : image Api (presignedUrl)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,5 +209,9 @@ project(':module-image-service') {
         runtimeOnly 'com.h2database:h2'
 
         implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+        // Spring Cloud AWS
+        implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+        implementation 'software.amazon.awssdk:s3:2.20.20' // AWS S3 SDK
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -197,3 +197,17 @@ project(':module-gateway-service') {
         implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     }
 }
+
+project(':module-image-service') {
+    dependencies {
+        implementation project(':module-common')
+
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+        runtimeOnly 'com.h2database:h2'
+
+        implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    }
+}

--- a/module-common/src/main/java/com/fashionmall/common/exception/ErrorResponseCode.java
+++ b/module-common/src/main/java/com/fashionmall/common/exception/ErrorResponseCode.java
@@ -24,9 +24,13 @@ public enum ErrorResponseCode {
     DUPLICATE_COUPON_NAME(HttpStatus.CONFLICT, "이미 존재하는 쿠폰명 입니다."),
     JWT_NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "유효하지 않은 토큰입니다."),
 
+    WRONG_ID(HttpStatus.BAD_REQUEST, "아이디를 다시 확인해주세요"),
     // Item
     WRONG_ITEM_ID(HttpStatus.BAD_REQUEST, "상품 관련 ID를 다시 확인해주세요"),
-    WRONG_CATEGORY_ID(HttpStatus.BAD_REQUEST, "카테고리 관련 ID를 다시 확인해주세요");
+    WRONG_CATEGORY_ID(HttpStatus.BAD_REQUEST, "카테고리 관련 ID를 다시 확인해주세요"),
+
+    // Image
+    NOT_FOUND_S3(HttpStatus.NOT_FOUND, "이미지가 S3에 존재하지 않습니다.");
 
 
     private final HttpStatus status;

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/dto/ImageDataDto.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/dto/ImageDataDto.java
@@ -1,0 +1,17 @@
+package com.fashionmall.common.moduleApi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageDataDto {
+
+    private Long id;
+    private String url;
+
+}

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/dto/ImageUploadDto.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/dto/ImageUploadDto.java
@@ -1,0 +1,22 @@
+package com.fashionmall.common.moduleApi.dto;
+
+import com.fashionmall.common.moduleApi.enums.ImageTypeEnum;
+import com.fashionmall.common.moduleApi.enums.ReferenceTypeEnum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.antlr.v4.runtime.misc.NotNull;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageUploadDto {
+
+    private String fileName;
+    private Long referenceId; // ex. itemId Or reviewId
+    private ReferenceTypeEnum referenceType; // (Enum) ITEM Or REVIEW
+    private ImageTypeEnum imageType; // (Enum) MAIN Or DESCRIPTION
+
+}

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/enums/ImageTypeEnum.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/enums/ImageTypeEnum.java
@@ -1,0 +1,15 @@
+package com.fashionmall.common.moduleApi.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.security.Principal;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageTypeEnum {
+
+    MAIN ("메인이미지"), DESCRIPTION ("서브이미지");
+
+    private final String imageType;
+}

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/enums/ReferenceTypeEnum.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/enums/ReferenceTypeEnum.java
@@ -1,0 +1,13 @@
+package com.fashionmall.common.moduleApi.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReferenceTypeEnum {
+
+    ITEM ("상품"), REVIEW ("리뷰");
+
+    private final String referenceType;
+}

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
@@ -22,15 +22,21 @@ public class ModuleApiUtil {
 
     private final String imageApi = "http://localhost:8000/api/image";
 
-    public Map <Long, String> uploadImageApi(List<ImageUploadDto> imageUploadDto) {
-        CommonResponse<Map<Long, String>> uploadImageApi = webClientUtil.post(
-                imageApi + "/uploadImageApi",
-                imageUploadDto,
-                new ParameterizedTypeReference<CommonResponse<Map<Long,String>>>() {}, // 응답 타입 명시
+    public List<ImageDataDto> getImageApi (List<Long> imageId) {
+        // referenceIds를 쿼리 파라미터로 변환
+        String imageIdParam = imageId.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+
+        // API 호출
+        CommonResponse<List<ImageDataDto>> getImageApi = webClientUtil.get(
+                imageApi + "/getImageApi?imageId=" + imageIdParam,
+                new ParameterizedTypeReference<CommonResponse<List<ImageDataDto>>>() {},
+                null, // 쿼리 파라미터는 URL에 포함되므로 null
                 headers()
         );
 
-        return uploadImageApi.getData();
+        return getImageApi.getData();
     }
 
     private Map<String, String> headers (){

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
@@ -22,21 +22,19 @@ public class ModuleApiUtil {
 
     private final String imageApi = "http://localhost:8000/api/image";
 
-    public List<ImageDataDto> getImageApi (List<Long> imageId) {
-        // referenceIds를 쿼리 파라미터로 변환
+    public List <Long> deleteImageApi (List<Long> imageId) {
+
         String imageIdParam = imageId.stream()
                 .map(String::valueOf)
                 .collect(Collectors.joining(","));
 
-        // API 호출
-        CommonResponse<List<ImageDataDto>> getImageApi = webClientUtil.get(
-                imageApi + "/getImageApi?imageId=" + imageIdParam,
-                new ParameterizedTypeReference<CommonResponse<List<ImageDataDto>>>() {},
-                null, // 쿼리 파라미터는 URL에 포함되므로 null
+        CommonResponse <List<Long>> deleteImageApi = webClientUtil.delete(
+                imageApi + "/deleteImageApi?imageId=" + imageIdParam,
+                new ParameterizedTypeReference<CommonResponse<List<Long>>>() {},
                 headers()
         );
 
-        return getImageApi.getData();
+        return deleteImageApi.getData();
     }
 
     private Map<String, String> headers (){

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
@@ -58,16 +58,43 @@ public class ModuleApiUtil {
     }
 
     // image
-    public List<Long> deleteImageApi (List < Long > imageId) {
+    public Map <Long, String> uploadImageApi(List<ImageUploadDto> imageUploadDto) {
+        CommonResponse<Map<Long, String>> uploadImageApi = webClientUtil.post(
+                imageApi + "/uploadImageApi",
+                imageUploadDto,
+                new ParameterizedTypeReference<CommonResponse<Map<Long,String>>>() {},
+                headers()
+        );
+
+        return uploadImageApi.getData();
+    }
+
+    public List<ImageDataDto> getImageApi (List<Long> imageId) {
+        // referenceIds를 쿼리 파라미터로 변환
+        String imageIdParam = imageId.stream()
+                .map(id -> "imageId=" + id)
+                .collect(Collectors.joining("&"));
+
+        // API 호출
+        CommonResponse<List<ImageDataDto>> getImageApi = webClientUtil.get(
+                imageApi + "/getImageApi?" + imageIdParam,
+                new ParameterizedTypeReference<CommonResponse<List<ImageDataDto>>>() {},
+                null, // 쿼리 파라미터는 URL에 포함되므로 null
+                headers()
+        );
+
+        return getImageApi.getData();
+    }
+
+    public List <Long> deleteImageApi (List<Long> imageId) {
 
         String imageIdParam = imageId.stream()
-                .map(String::valueOf)
-                .collect(Collectors.joining(","));
+                .map(id -> "imageId=" + id)
+                .collect(Collectors.joining("&"));
 
         CommonResponse<List<Long>> deleteImageApi = webClientUtil.delete(
-                imageApi + "/deleteImageApi?imageId=" + imageIdParam,
-                new ParameterizedTypeReference<CommonResponse<List<Long>>>() {
-                },
+                imageApi + "/deleteImageApi?" + imageIdParam,
+                new ParameterizedTypeReference<CommonResponse<List<Long>>>() {},
                 headers()
         );
 

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
@@ -1,0 +1,40 @@
+package com.fashionmall.common.moduleApi.util;
+
+import com.fashionmall.common.moduleApi.dto.ImageDataDto;
+import com.fashionmall.common.moduleApi.dto.ImageUploadDto;
+import com.fashionmall.common.response.CommonResponse;
+import com.fashionmall.common.util.WebClientUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ModuleApiUtil {
+
+    private final WebClientUtil webClientUtil;
+
+    private final String imageApi = "http://localhost:8000/api/image";
+
+    public Map <Long, String> uploadImageApi(List<ImageUploadDto> imageUploadDto) {
+        CommonResponse<Map<Long, String>> uploadImageApi = webClientUtil.post(
+                imageApi + "/uploadImageApi",
+                imageUploadDto,
+                new ParameterizedTypeReference<CommonResponse<Map<Long,String>>>() {}, // 응답 타입 명시
+                headers()
+        );
+
+        return uploadImageApi.getData();
+    }
+
+    private Map<String, String> headers (){
+        return Map.of (HttpHeaders.CONTENT_TYPE, "application/json");
+    }
+
+}

--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
@@ -60,7 +60,7 @@ public class ModuleApiUtil {
     // image
     public Map <Long, String> uploadImageApi(List<ImageUploadDto> imageUploadDto) {
         CommonResponse<Map<Long, String>> uploadImageApi = webClientUtil.post(
-                imageApi + "/uploadImageApi",
+                imageApi + "/uploadImage",
                 imageUploadDto,
                 new ParameterizedTypeReference<CommonResponse<Map<Long,String>>>() {},
                 headers()
@@ -77,7 +77,7 @@ public class ModuleApiUtil {
 
         // API 호출
         CommonResponse<List<ImageDataDto>> getImageApi = webClientUtil.get(
-                imageApi + "/getImageApi?" + imageIdParam,
+                imageApi + "/getImage?" + imageIdParam,
                 new ParameterizedTypeReference<CommonResponse<List<ImageDataDto>>>() {},
                 null, // 쿼리 파라미터는 URL에 포함되므로 null
                 headers()
@@ -93,7 +93,7 @@ public class ModuleApiUtil {
                 .collect(Collectors.joining("&"));
 
         CommonResponse<List<Long>> deleteImageApi = webClientUtil.delete(
-                imageApi + "/deleteImageApi?" + imageIdParam,
+                imageApi + "/deleteImage?" + imageIdParam,
                 new ParameterizedTypeReference<CommonResponse<List<Long>>>() {},
                 headers()
         );

--- a/module-gateway-service/src/main/java/com/fashionmall/gateway/config/GatewayRoutingConfig.java
+++ b/module-gateway-service/src/main/java/com/fashionmall/gateway/config/GatewayRoutingConfig.java
@@ -15,6 +15,8 @@ public class GatewayRoutingConfig {
                         .uri("lb://module-cart-service"))
                 .route("COUPON-SERVICE", r -> r.path("/api/coupon/**")
                         .uri("lb://module-coupon-service"))
+                .route("IMAGE-SERVICE", r -> r.path("/api/image/**")
+                        .uri("lb://module-image-service"))
                 .route("ITEM-SERVICE", r -> r.path("/api/item/**")
                         .uri("lb://module-item-service"))
                 .route("ORDER-SERVICE", r -> r.path("/api/order/**")

--- a/module-image-service/src/main/java/com/fashionmall/image/ImageApplication.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/ImageApplication.java
@@ -1,0 +1,15 @@
+package com.fashionmall.image;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"com.fashionmall.image", "com.fashionmall.common"})
+public class ImageApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ImageApplication.class, args);
+    }
+
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/config/S3Config.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/config/S3Config.java
@@ -1,0 +1,43 @@
+package com.fashionmall.image.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+        );
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+        }
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
@@ -20,10 +20,10 @@ public class ImageApiController {
     private final ImageService imageService;
     private final ModuleApiUtil moduleApiUtil;
 
-    @PostMapping("/uploadImageApi")
-    public CommonResponse<Map<Long,String>> uploadImageApi (@RequestBody List<ImageUploadDto> imageUploadDto) {
+    @GetMapping ("/getImageApi")
+    public CommonResponse<List<ImageDataDto>> getImageApi (@RequestParam List<Long> imageId) {
         Long workerId = 1L;
-        return ApiResponseUtil.success(imageService.uploadImageApi(imageUploadDto, workerId));
+        return ApiResponseUtil.success(imageService.getImageApi(imageId, workerId));
     }
 
 }

--- a/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
@@ -20,6 +20,18 @@ public class ImageApiController {
     private final ImageService imageService;
     private final ModuleApiUtil moduleApiUtil;
 
+    @PostMapping("/uploadImageApi")
+    public CommonResponse<Map<Long,String>> uploadImageApi (@RequestBody List<ImageUploadDto> imageUploadDto) {
+        Long workerId = 1L;
+        return ApiResponseUtil.success(imageService.uploadImageApi(imageUploadDto, workerId));
+    }
+
+    @GetMapping ("/getImageApi")
+    public CommonResponse<List<ImageDataDto>> getImageApi (@RequestParam List<Long> imageId) {
+        Long workerId = 1L;
+        return ApiResponseUtil.success(imageService.getImageApi(imageId, workerId));
+    }
+
     @DeleteMapping ("/deleteImageApi")
     public CommonResponse <List<Long>> deleteImageApi (@RequestParam List<Long> imageId) {
         Long workerId = 1L;

--- a/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
@@ -20,10 +20,10 @@ public class ImageApiController {
     private final ImageService imageService;
     private final ModuleApiUtil moduleApiUtil;
 
-    @GetMapping ("/getImageApi")
-    public CommonResponse<List<ImageDataDto>> getImageApi (@RequestParam List<Long> imageId) {
+    @DeleteMapping ("/deleteImageApi")
+    public CommonResponse <List<Long>> deleteImageApi (@RequestParam List<Long> imageId) {
         Long workerId = 1L;
-        return ApiResponseUtil.success(imageService.getImageApi(imageId, workerId));
+        return ApiResponseUtil.success(imageService.deleteImageApi(imageId, workerId));
     }
 
 }

--- a/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
@@ -20,19 +20,19 @@ public class ImageApiController {
     private final ImageService imageService;
     private final ModuleApiUtil moduleApiUtil;
 
-    @PostMapping("/uploadImageApi")
+    @PostMapping("/uploadImage")
     public CommonResponse<Map<Long,String>> uploadImageApi (@RequestBody List<ImageUploadDto> imageUploadDto) {
         Long workerId = 1L;
         return ApiResponseUtil.success(imageService.uploadImageApi(imageUploadDto, workerId));
     }
 
-    @GetMapping ("/getImageApi")
+    @GetMapping ("/getImage")
     public CommonResponse<List<ImageDataDto>> getImageApi (@RequestParam List<Long> imageId) {
         Long workerId = 1L;
         return ApiResponseUtil.success(imageService.getImageApi(imageId, workerId));
     }
 
-    @DeleteMapping ("/deleteImageApi")
+    @DeleteMapping ("/deleteImage")
     public CommonResponse <List<Long>> deleteImageApi (@RequestParam List<Long> imageId) {
         Long workerId = 1L;
         return ApiResponseUtil.success(imageService.deleteImageApi(imageId, workerId));

--- a/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/controller/ImageApiController.java
@@ -1,0 +1,30 @@
+package com.fashionmall.image.controller;
+
+import com.fashionmall.common.moduleApi.dto.ImageDataDto;
+import com.fashionmall.common.moduleApi.dto.ImageUploadDto;
+import com.fashionmall.common.moduleApi.util.ModuleApiUtil;
+import com.fashionmall.common.response.CommonResponse;
+import com.fashionmall.common.util.ApiResponseUtil;
+import com.fashionmall.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/image")
+public class ImageApiController {
+
+    private final ImageService imageService;
+    private final ModuleApiUtil moduleApiUtil;
+
+    @PostMapping("/uploadImageApi")
+    public CommonResponse<Map<Long,String>> uploadImageApi (@RequestBody List<ImageUploadDto> imageUploadDto) {
+        Long workerId = 1L;
+        return ApiResponseUtil.success(imageService.uploadImageApi(imageUploadDto, workerId));
+    }
+
+}
+

--- a/module-image-service/src/main/java/com/fashionmall/image/entity/Image.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/entity/Image.java
@@ -1,0 +1,39 @@
+package com.fashionmall.image.entity;
+
+import com.fashionmall.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "image")
+@Slf4j(topic = "이미지 테이블")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String url;
+
+    @Column(nullable = false)
+    private String uniqueFileName;
+
+    @OneToMany(mappedBy = "image", cascade = CascadeType.ALL, orphanRemoval = true) // image가 parent이고 imageMapping이 child
+    private List<ImageMapping> imageMappings = new ArrayList<>();
+
+    @Builder
+    public Image (String url, String uniqueFileName) {
+        this.url = url;
+        this.uniqueFileName = uniqueFileName;
+    }
+
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/entity/ImageMapping.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/entity/ImageMapping.java
@@ -1,0 +1,43 @@
+package com.fashionmall.image.entity;
+
+import com.fashionmall.common.entity.BaseEntity;
+import com.fashionmall.common.moduleApi.enums.ImageTypeEnum;
+import com.fashionmall.common.moduleApi.enums.ReferenceTypeEnum;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Entity
+@Getter
+@Table(name = "image_mapping")
+@Slf4j(topic = "이미지 매핑 테이블")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageMapping extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne @JoinColumn(name = "image_id", nullable = false)
+    private Image image;
+
+    @Enumerated(EnumType.STRING)
+    private ReferenceTypeEnum referenceType;
+
+    @Column(nullable = false)
+    private Long referenceId;
+
+    @Enumerated(EnumType.STRING)
+    private ImageTypeEnum imageType;
+
+    @Builder
+    public ImageMapping (Image image, ReferenceTypeEnum referenceType, Long referenceId, ImageTypeEnum imageType) {
+        this.image = image;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+        this.imageType = imageType;
+    }
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/repository/ImageMappingRepository.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/repository/ImageMappingRepository.java
@@ -1,0 +1,7 @@
+package com.fashionmall.image.repository;
+
+import com.fashionmall.image.entity.ImageMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageMappingRepository extends JpaRepository <ImageMapping, Long> {
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/repository/ImageRepository.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/repository/ImageRepository.java
@@ -1,0 +1,9 @@
+package com.fashionmall.image.repository;
+
+
+import com.fashionmall.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository <Image, Long> {
+
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
@@ -14,6 +14,6 @@ import java.util.Map;
 
 public interface ImageService {
 
-    Map<Long,String> uploadImageApi (List<ImageUploadDto> imageUploadDto, Long workerId);
+    List<ImageDataDto> getImageApi (List<Long> imageId, Long workerId);
 
 }

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
@@ -3,11 +3,6 @@ package com.fashionmall.image.service;
 
 import com.fashionmall.common.moduleApi.dto.ImageDataDto;
 import com.fashionmall.common.moduleApi.dto.ImageUploadDto;
-import com.fashionmall.common.response.PageInfoResponseDto;
-import com.fashionmall.image.dto.request.ImageUploadRequestDto;
-import com.fashionmall.image.dto.response.ImageListResponseDto;
-import com.fashionmall.image.dto.response.ImageUploadResponseDto;
-
 
 import java.util.List;
 import java.util.Map;

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
@@ -14,5 +14,9 @@ import java.util.Map;
 
 public interface ImageService {
 
+    Map<Long,String> uploadImageApi (List<ImageUploadDto> imageUploadDto, Long workerId);
+
+    List<ImageDataDto> getImageApi (List<Long> imageId, Long workerId);
+
     List<Long> deleteImageApi (List<Long> imageId, Long workerId);
 }

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
@@ -14,6 +14,5 @@ import java.util.Map;
 
 public interface ImageService {
 
-    List<ImageDataDto> getImageApi (List<Long> imageId, Long workerId);
-
+    List<Long> deleteImageApi (List<Long> imageId, Long workerId);
 }

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageService.java
@@ -1,0 +1,19 @@
+package com.fashionmall.image.service;
+
+
+import com.fashionmall.common.moduleApi.dto.ImageDataDto;
+import com.fashionmall.common.moduleApi.dto.ImageUploadDto;
+import com.fashionmall.common.response.PageInfoResponseDto;
+import com.fashionmall.image.dto.request.ImageUploadRequestDto;
+import com.fashionmall.image.dto.response.ImageListResponseDto;
+import com.fashionmall.image.dto.response.ImageUploadResponseDto;
+
+
+import java.util.List;
+import java.util.Map;
+
+public interface ImageService {
+
+    Map<Long,String> uploadImageApi (List<ImageUploadDto> imageUploadDto, Long workerId);
+
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
@@ -48,6 +48,60 @@ public class ImageServiceImpl implements ImageService {
 
     @Override
     @Transactional
+    public Map<Long,String> uploadImageApi (List<ImageUploadDto> imageUploadDto, Long workerId) {
+        // 사용자 검증
+
+        Map<Long,String> response = new HashMap<>();
+
+        for (ImageUploadDto uploadInfo : imageUploadDto ) {
+
+            String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+
+            String uniqueFileName = String.format("%s/%s/profile_%s_%s_%s",
+                    uploadInfo.getReferenceType(),
+                    uploadInfo.getImageType(),
+                    timestamp,
+                    uploadInfo.getFileName(),
+                    UUID.randomUUID()
+            );
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(uniqueFileName)
+                    .build();
+
+            PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(10))
+                    .putObjectRequest(putObjectRequest)
+                    .build();
+
+            PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
+
+            Image image = Image.builder()
+                    .url(String.valueOf(presignedPutObjectRequest.url()))
+                    .uniqueFileName(uniqueFileName)
+                    .build();
+            imageRepository.save(image);
+
+            ImageMapping imageMapping = ImageMapping.builder()
+                    .image(image)
+                    .referenceType(uploadInfo.getReferenceType())
+                    .referenceId(uploadInfo.getReferenceId())
+                    .imageType(uploadInfo.getImageType())
+                    .build();
+            imageMappingRepository.save(imageMapping);
+            image.getImageMappings().add(imageMapping);
+
+            response.put(image.getId(), image.getUrl());
+
+        }
+
+        return response;
+
+    }
+
+    @Override
+    @Transactional
     public List<ImageDataDto> getImageApi (List<Long> imageId, Long workerId) {
         // 본인 인증
 
@@ -81,6 +135,27 @@ public class ImageServiceImpl implements ImageService {
         }
 
         return imageDataDtoList;
+    }
+
+    @Override
+    @Transactional
+    public List<Long> deleteImageApi (List<Long> imageId, Long workerId) {
+        // 본인인증
+
+        for (Long imageIds : imageId) {
+            Image image = imageRepository.findById(imageIds)
+                    .orElseThrow(() -> new CustomException(ErrorResponseCode.WRONG_ID));
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(image.getUniqueFileName())
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+
+            imageRepository.deleteById(imageIds);
+        }
+
+        return imageId;
     }
 
 }

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
@@ -48,25 +48,23 @@ public class ImageServiceImpl implements ImageService {
 
     @Override
     @Transactional
-    public List<ImageDataDto> getImageApi (List<Long> imageId, Long workerId) {
-        // 본인 인증
-
-        List<ImageDataDto> imageDataDtoList = new ArrayList<>();
+    public List<Long> deleteImageApi (List<Long> imageId, Long workerId) {
+        // 본인인증
 
         for (Long imageIds : imageId) {
-
             Image image = imageRepository.findById(imageIds)
-                    .orElseThrow(()-> new CustomException(ErrorResponseCode.BAD_REQUEST));
+                    .orElseThrow(() -> new CustomException(ErrorResponseCode.WRONG_ID));
 
-            ImageDataDto imageDataDto = ImageDataDto.builder()
-                    .id(image.getId())
-                    .url(image.getUrl())
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(image.getUniqueFileName())
                     .build();
+            s3Client.deleteObject(deleteObjectRequest);
 
-            imageDataDtoList.add(imageDataDto);
+            imageRepository.deleteById(imageIds);
         }
 
-        return imageDataDtoList;
+        return imageId;
     }
 
 }

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
@@ -1,0 +1,103 @@
+package com.fashionmall.image.service;
+
+import com.amazonaws.SdkClientException;
+import com.fashionmall.common.exception.CustomException;
+import com.fashionmall.common.exception.ErrorResponseCode;
+
+import com.fashionmall.common.moduleApi.dto.ImageDataDto;
+import com.fashionmall.common.moduleApi.dto.ImageUploadDto;
+import com.fashionmall.common.response.PageInfoResponseDto;
+import com.fashionmall.image.dto.request.ImageUploadRequestDto;
+import com.fashionmall.image.dto.response.ImageListResponseDto;
+import com.fashionmall.image.dto.response.ImageUploadResponseDto;
+import com.fashionmall.image.entity.Image;
+import com.fashionmall.image.entity.ImageMapping;
+import com.fashionmall.image.repository.ImageMappingRepository;
+import com.fashionmall.image.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "ImageService")
+@Transactional(readOnly = true)
+public class ImageServiceImpl implements ImageService {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final ImageRepository imageRepository;
+    private final ImageMappingRepository imageMappingRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    @Transactional
+    public Map<Long,String> uploadImageApi (List<ImageUploadDto> imageUploadDto, Long workerId) {
+        // 사용자 검증
+
+        Map<Long,String> response = new HashMap<>();
+
+        for (ImageUploadDto uploadInfo : imageUploadDto ) {
+
+            String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+
+            String uniqueFileName = String.format("%s/%s/profile_%s_%s_%s",
+                    uploadInfo.getReferenceType(),
+                    uploadInfo.getImageType(),
+                    timestamp,
+                    uploadInfo.getFileName(),
+                    UUID.randomUUID()
+            );
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(uniqueFileName)
+                    .build();
+
+            PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(10))
+                    .putObjectRequest(putObjectRequest)
+                    .build();
+
+            PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
+
+            Image image = Image.builder()
+                    .url(String.valueOf(presignedPutObjectRequest.url()))
+                    .uniqueFileName(uniqueFileName)
+                    .build();
+            imageRepository.save(image);
+
+            ImageMapping imageMapping = ImageMapping.builder()
+                    .image(image)
+                    .referenceType(uploadInfo.getReferenceType())
+                    .referenceId(uploadInfo.getReferenceId())
+                    .imageType(uploadInfo.getImageType())
+                    .build();
+            imageMappingRepository.save(imageMapping);
+            image.getImageMappings().add(imageMapping);
+
+            response.put(image.getId(), image.getUrl());
+
+        }
+
+        return response;
+
+    }
+
+}

--- a/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
+++ b/module-image-service/src/main/java/com/fashionmall/image/service/ImageServiceImpl.java
@@ -1,15 +1,10 @@
 package com.fashionmall.image.service;
 
-import com.amazonaws.SdkClientException;
 import com.fashionmall.common.exception.CustomException;
 import com.fashionmall.common.exception.ErrorResponseCode;
 
 import com.fashionmall.common.moduleApi.dto.ImageDataDto;
 import com.fashionmall.common.moduleApi.dto.ImageUploadDto;
-import com.fashionmall.common.response.PageInfoResponseDto;
-import com.fashionmall.image.dto.request.ImageUploadRequestDto;
-import com.fashionmall.image.dto.response.ImageListResponseDto;
-import com.fashionmall.image.dto.response.ImageUploadResponseDto;
 import com.fashionmall.image.entity.Image;
 import com.fashionmall.image.entity.ImageMapping;
 import com.fashionmall.image.repository.ImageMappingRepository;
@@ -17,7 +12,6 @@ import com.fashionmall.image.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.S3Client;

--- a/module-image-service/src/main/resources/application-local.yml
+++ b/module-image-service/src/main/resources/application-local.yml
@@ -1,0 +1,25 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+
+cloud:
+  aws:
+    credentials:
+      accessKey:
+      secretKey:
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: s3-bucket-shopdb

--- a/module-image-service/src/main/resources/application.yml
+++ b/module-image-service/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8086
+
 spring:
   application:
     name: module-item-service

--- a/module-image-service/src/main/resources/application.yml
+++ b/module-image-service/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: module-item-service
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  profiles:
+    active: local
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+
+    service-url:
+      defaultZone: http://localhost:8761/eureka/

--- a/module-image-service/src/main/resources/application.yml
+++ b/module-image-service/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   application:
-    name: module-item-service
+    name: module-image-service
   jpa:
     hibernate:
       ddl-auto: validate

--- a/module-image-service/src/test/java/com/fashionmall/image/ImageApplicationTest.java
+++ b/module-image-service/src/test/java/com/fashionmall/image/ImageApplicationTest.java
@@ -1,0 +1,11 @@
+package com.fashionmall.image;
+
+import org.junit.jupiter.api.Test;
+
+class ImageApplicationTest {
+
+    @Test
+    void test() {
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,4 @@ include 'module-review-service'
 include 'module-cart-service'
 include 'module-eureka-server'
 include 'module-gateway-service'
-
+include 'module-image-service'


### PR DESCRIPTION
## 📝작업 내용
presignedUrl 기반으로 S3 / IAM 연결을 해놓은 상태입니다.
필요하시다면, local.yml에 slack에 올려놓은 access / secret access key를 넣고 사용하시면 됩니다 (공지에 있습니다) 
테스트시 하시면 되고, 커밋 할때는 해당 key를 빼주세요! (보안 & 오류 방지)

기존에는 item에 있었는데, Image 모듈로 따로 빼서 작성했습니다.
image는 수정이 따로 없습니다. 등록 -> 삭제 -> 등록으로 되어 있습니다.
이미지가 자체적으로 사용된다기 보단 상품 / 리뷰쪽에 gateway로써의 역할이 많아 코드 내용이 거의 겹쳐서 gateway 코드로만 가면 어떨까 싶습니다. (필요하시면 말해주세요!)

fbddd4057d314bb62c510ce7f5cfe28db4e54c7d 모듈 init
7e398a44d5a7189ecd778ea89eed820eb12d312e 모듈 디렉토리 init
278a248cd5ddc4631d1394864ab92f8917463ac4 b8432278d650eb01c201caabfecc993f32623afa 유레카, 게이트웨이 세팅
2dae5b7150a977ef0895a78e8c3833d5dad5fb42 aws 설정

d22dad0fafa4c948a164f6835986e872e7eb9aaa s3 config
3ea0dead5b3ca50394d7d4a32670cedb65787115 image entity, repository

7d0881b71a853231aeabed10cdff2c8a9b658b24 57c3604a434fc439f1499d03c36151b362d14ce9 image 등록 gateway
834d079d623195b69abb7c0e48232f87086b5f78 d513a7b3752b3854add35c35156c5aac6ecb4f1b image 조회 gateway
496881cdb4d77e006e7e6a48c29727da7e39a87b image 삭제 gateway
[303bda9](https://github.com/team-fashionmall/fashionmall/pull/24/commits/303bda9b2b8037372a65ade24002f05fadd80225) 등록, 조회, 삭제 전체 코드

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 상품 / 리뷰에 imageId를 반환시켜 저장하여 사용하도록 되어 있습니다.
- 게이트웨이가 아닌 image 자체의 등록/조회/삭제 코드는 뺐는데 필요하시면 알려주세요
- 게이트웨이 response 값을 추가하실 부분 알려주시면 수정하겠습니다. 

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## 🔗참고 링크(선택)

- 리뷰어가 참고할 링크(블로그 혹은 연관작업PR)가 있으면 작성해주세요

## ⏰기한

- 2024-xx-xx