### PR TITLE
refactor: front, back sync 작업

### DIFF
--- a/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
+++ b/module-common/src/main/java/com/fashionmall/common/moduleApi/util/ModuleApiUtil.java
@@ -25,7 +25,7 @@ public class ModuleApiUtil {
     public List<CouponDto> getUserCouponApi(Long userId) {
         Map<String, String> headers = Map.of(
                 HttpHeaders.CONTENT_TYPE, "application/json");
-        CommonResponse<List<CouponDto>> listCommonResponse = webClientUtil.get(couponApi + "/getCoupon/" + userId, new ParameterizedTypeReference<CommonResponse<List<CouponDto>>>() {
+        CommonResponse<List<CouponDto>> listCommonResponse = webClientUtil.get(couponApi + "/getCoupon", new ParameterizedTypeReference<CommonResponse<List<CouponDto>>>() {
         }, null, headers);
         return listCommonResponse.getData();
     }

--- a/module-coupon-service/src/main/java/com/fashionmall/coupon/controller/ApiCouponController.java
+++ b/module-coupon-service/src/main/java/com/fashionmall/coupon/controller/ApiCouponController.java
@@ -6,7 +6,6 @@ import com.fashionmall.common.util.ApiResponseUtil;
 import com.fashionmall.coupon.service.CouponService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,8 +18,9 @@ public class ApiCouponController {
 
     private final CouponService couponService;
 
-    @GetMapping("/getCoupon/{userId}")
-    public CommonResponse<List<CouponDto>> getCoupon(@PathVariable(value = "userId") Long userId) {
+    @GetMapping("/getCoupon")
+    public CommonResponse<List<CouponDto>> getCoupon() {
+        Long userId = 1L; //로그인 인증 기능 추가
         return ApiResponseUtil.success(couponService.getUserCouponsToApi(userId));
     }
 }

--- a/module-coupon-service/src/main/java/com/fashionmall/coupon/controller/CouponQueryController.java
+++ b/module-coupon-service/src/main/java/com/fashionmall/coupon/controller/CouponQueryController.java
@@ -8,6 +8,8 @@ import com.fashionmall.coupon.service.CouponService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class CouponQueryController {
@@ -24,10 +26,9 @@ public class CouponQueryController {
 
     //다운로드가능쿠폰목록조회
     @GetMapping("/coupon/download")
-    public CommonResponse<PageInfoResponseDto<UserCouponResponseDto>> getUserCouponDownloadList(@RequestParam(defaultValue = "1") int pageNo,
-                                                                                                @RequestParam(defaultValue = "10") int size) {
+    public CommonResponse<List<UserCouponResponseDto>> getUserCouponDownloadList() {
         Long id = 1L; //임시부여
-        return ApiResponseUtil.success(couponService.getDownloadableCoupons(id, pageNo, size));
+        return ApiResponseUtil.success(couponService.getDownloadableCoupons(id));
     }
 
     //쿠폰다운로드

--- a/module-coupon-service/src/main/java/com/fashionmall/coupon/dto/response/UserCouponResponseDto.java
+++ b/module-coupon-service/src/main/java/com/fashionmall/coupon/dto/response/UserCouponResponseDto.java
@@ -2,7 +2,10 @@ package com.fashionmall.coupon.dto.response;
 
 import com.fashionmall.coupon.entity.Coupon;
 import com.fashionmall.coupon.enums.DiscountType;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +15,7 @@ import java.time.LocalDateTime;
 @ToString
 public class UserCouponResponseDto {
 
+    private Long couponId;
     private String name;
     private DiscountType discountType;
     private int discountValue;
@@ -23,6 +27,7 @@ public class UserCouponResponseDto {
 
     public static UserCouponResponseDto from(Coupon coupon) {
         return new UserCouponResponseDto(
+                coupon.getId(),
                 coupon.getName(),
                 coupon.getDiscountType(),
                 coupon.getDiscountValue(),

--- a/module-coupon-service/src/main/java/com/fashionmall/coupon/repository/CouponRepositoryCustom.java
+++ b/module-coupon-service/src/main/java/com/fashionmall/coupon/repository/CouponRepositoryCustom.java
@@ -14,7 +14,7 @@ public interface CouponRepositoryCustom {
 
     PageInfoResponseDto<UserCouponResponseDto> findUserCouponByUserIdToApi(Long userId, Pageable pageable);
 
-    PageInfoResponseDto<UserCouponResponseDto> findDownloadableCoupon(Long userId, Pageable pageable);
+    List<UserCouponResponseDto> findDownloadableCoupon(Long userId);
 
     List<CouponDto> findUserCouponByUserIdToApi(Long userId);
 

--- a/module-coupon-service/src/main/java/com/fashionmall/coupon/repository/CouponRepositoryImpl.java
+++ b/module-coupon-service/src/main/java/com/fashionmall/coupon/repository/CouponRepositoryImpl.java
@@ -67,6 +67,7 @@ public class CouponRepositoryImpl implements CouponRepositoryCustom {
 
         List<UserCouponResponseDto> content = queryFactory
                 .select(Projections.constructor(UserCouponResponseDto.class,
+                        coupon.id,
                         coupon.name,
                         coupon.discountType,
                         coupon.discountValue,
@@ -101,13 +102,11 @@ public class CouponRepositoryImpl implements CouponRepositoryCustom {
     }
 
     @Override
-    public PageInfoResponseDto<UserCouponResponseDto> findDownloadableCoupon(Long userId, Pageable pageable) {
+    public List<UserCouponResponseDto> findDownloadableCoupon(Long userId) {
 
-        int offset = (int) pageable.getOffset();
-        int size = pageable.getPageSize();
-
-        List<UserCouponResponseDto> content = queryFactory
+        return queryFactory
                 .select(Projections.constructor(UserCouponResponseDto.class,
+                        coupon.id,
                         coupon.name,
                         coupon.discountType,
                         coupon.discountValue,
@@ -124,25 +123,7 @@ public class CouponRepositoryImpl implements CouponRepositoryCustom {
                         coupon.endDate.after(LocalDateTime.now()),
                         userCoupon.id.isNull())
                 .orderBy(coupon.id.desc())
-                .offset(offset)
-                .limit(size)
                 .fetch();
-
-        Long fetchOne = queryFactory
-                .select(coupon.count())
-                .from(coupon)
-                .leftJoin(userCoupon)
-                .on(userCoupon.coupon.eq(coupon)
-                        .and(userCoupon.userId.eq(userId)))
-                .where(coupon.couponType.eq(CouponType.DOWNLOAD),
-                        coupon.status.eq(CouponStatus.ACTIVATED),
-                        coupon.endDate.after(LocalDateTime.now()),
-                        userCoupon.id.isNull())
-                .fetchOne();
-
-        int totalCount = fetchOne.intValue();
-
-        return PageInfoResponseDto.of(pageable, content, totalCount);
     }
 
     @Override

--- a/module-coupon-service/src/main/java/com/fashionmall/coupon/service/CouponService.java
+++ b/module-coupon-service/src/main/java/com/fashionmall/coupon/service/CouponService.java
@@ -21,7 +21,7 @@ public interface CouponService {
 
     PageInfoResponseDto<UserCouponResponseDto> getUserCoupons(Long userId, int pageNo, int size);
 
-    PageInfoResponseDto<UserCouponResponseDto> getDownloadableCoupons(Long userId, int pageNo, int size);
+    List<UserCouponResponseDto> getDownloadableCoupons(Long userId);
 
     Long downloadCoupon(Long userId, Long couponId);
 

--- a/module-coupon-service/src/main/java/com/fashionmall/coupon/service/CouponServiceImpl.java
+++ b/module-coupon-service/src/main/java/com/fashionmall/coupon/service/CouponServiceImpl.java
@@ -120,9 +120,8 @@ public class CouponServiceImpl implements CouponService {
     }
 
     @Override
-    public PageInfoResponseDto<UserCouponResponseDto> getDownloadableCoupons(Long userId, int pageNo, int size) {
-        PageRequest pageRequest = PageRequest.of(pageNo - 1, size);
-        return couponRepository.findDownloadableCoupon(userId, pageRequest);
+    public List<UserCouponResponseDto> getDownloadableCoupons(Long userId) {
+        return couponRepository.findDownloadableCoupon(userId);
     }
 
     @Override

--- a/module-order-service/src/main/java/com/fashionmall/order/controller/BillingKeyController.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/controller/BillingKeyController.java
@@ -1,13 +1,14 @@
 package com.fashionmall.order.controller;
 
 import com.fashionmall.common.response.CommonResponse;
-import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.common.util.ApiResponseUtil;
 import com.fashionmall.order.dto.request.BillingKeyRequestDto;
 import com.fashionmall.order.dto.response.UserBillingKeyResponseDto;
 import com.fashionmall.order.service.BillingKeyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,10 +23,9 @@ public class BillingKeyController {
     }
 
     @GetMapping("/billingKey")
-    public CommonResponse<PageInfoResponseDto<UserBillingKeyResponseDto>> getBillingKey(@RequestParam(defaultValue = "1") int pageNo,
-                                                                                        @RequestParam(defaultValue = "10") int size) {
+    public CommonResponse<List<UserBillingKeyResponseDto>> getBillingKey() {
         Long userId = 1L;
-        return ApiResponseUtil.success(billingKeyService.getUserBillingKeyList(userId, pageNo, size));
+        return ApiResponseUtil.success(billingKeyService.getUserBillingKeyList(userId));
     }
 
     @DeleteMapping("/billingKey/{billingKeyId}")

--- a/module-order-service/src/main/java/com/fashionmall/order/controller/OrderController.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/controller/OrderController.java
@@ -5,7 +5,6 @@ import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.common.util.ApiResponseUtil;
 import com.fashionmall.order.dto.request.OrderPaymentRequestDto;
 import com.fashionmall.order.dto.request.PaymentCancelRequestDto;
-import com.fashionmall.order.dto.response.OrdersCompleteResponseDto;
 import com.fashionmall.order.dto.response.OrdersDetailResponseDto;
 import com.fashionmall.order.dto.response.OrdersResponseDto;
 import com.fashionmall.order.service.OrdersService;
@@ -21,7 +20,7 @@ public class OrderController {
     private final PaymentService paymentService;
 
     @PostMapping("/order")
-    public CommonResponse<OrdersCompleteResponseDto> createOrderAndPayment(@RequestBody OrderPaymentRequestDto orderPaymentRequestDto) {
+    public CommonResponse<Long> createOrderAndPayment(@RequestBody OrderPaymentRequestDto orderPaymentRequestDto) {
 
         return ApiResponseUtil.success(ordersService.createAndPaymentOrder(orderPaymentRequestDto));
     }

--- a/module-order-service/src/main/java/com/fashionmall/order/dto/request/BillingKeyRequestDto.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/dto/request/BillingKeyRequestDto.java
@@ -22,7 +22,7 @@ public class BillingKeyRequestDto {
     @JsonProperty("pwd_2digit")
     private String pwd2digit;
 
-    public BillingKey toEntity(String cardName, String cardType, String customerUid) {
+    public BillingKey toEntity(String cardNumber, String cardName, String cardType, String customerUid) {
         return BillingKey
                 .builder()
                 .userId(userId)

--- a/module-order-service/src/main/java/com/fashionmall/order/dto/response/UserBillingKeyResponseDto.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/dto/response/UserBillingKeyResponseDto.java
@@ -1,6 +1,7 @@
 package com.fashionmall.order.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class UserBillingKeyResponseDto {
 
     private Long id;
@@ -21,10 +23,6 @@ public class UserBillingKeyResponseDto {
     @JsonProperty("card_type")
     private String cardType;
 
-    public UserBillingKeyResponseDto(Long id, String cardNickname, String cardName, String cardType) {
-        this.id = id;
-        this.cardNickname = cardNickname;
-        this.cardName = cardName;
-        this.cardType = cardType;
-    }
+    @JsonProperty("card_number")
+    private String cardNumber;
 }

--- a/module-order-service/src/main/java/com/fashionmall/order/repository/BillingKeyRepositoryCustom.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/repository/BillingKeyRepositoryCustom.java
@@ -1,12 +1,12 @@
 package com.fashionmall.order.repository;
 
-import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.order.dto.response.UserBillingKeyResponseDto;
-import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface BillingKeyRepositoryCustom {
 
-    PageInfoResponseDto<UserBillingKeyResponseDto> findBillingKeyByUserId(Long userId, Pageable pageable);
+    List<UserBillingKeyResponseDto> findBillingKeyByUserId(Long userId);
 
     String findCustomerUidById(Long id);
 }

--- a/module-order-service/src/main/java/com/fashionmall/order/repository/BillingKeyRepositoryImpl.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/repository/BillingKeyRepositoryImpl.java
@@ -1,11 +1,9 @@
 package com.fashionmall.order.repository;
 
-import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.order.dto.response.UserBillingKeyResponseDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,33 +17,19 @@ public class BillingKeyRepositoryImpl implements BillingKeyRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
 
-    public PageInfoResponseDto<UserBillingKeyResponseDto> findBillingKeyByUserId(Long userId, Pageable pageable) {
+    public List<UserBillingKeyResponseDto> findBillingKeyByUserId(Long userId) {
 
-        int offset = (int) pageable.getOffset();
-        int size = pageable.getPageSize();
-
-        List<UserBillingKeyResponseDto> content = queryFactory
+        return queryFactory
                 .select(Projections.constructor(UserBillingKeyResponseDto.class,
                         billingKey.id,
                         billingKey.cardNickname,
                         billingKey.cardName,
-                        billingKey.cardType))
+                        billingKey.cardType,
+                        billingKey.cardNumber))
                 .from(billingKey)
                 .where(billingKey.userId.eq(userId))
                 .orderBy(billingKey.id.asc())
-                .offset(offset)
-                .limit(size)
                 .fetch();
-
-        Long fetchOne = queryFactory
-                .select(billingKey.count())
-                .from(billingKey)
-                .where(billingKey.userId.eq(userId))
-                .fetchOne();
-
-        int totalCount = fetchOne.intValue();
-
-        return PageInfoResponseDto.of(pageable, content, totalCount);
     }
 
     @Override

--- a/module-order-service/src/main/java/com/fashionmall/order/repository/OrdersRepositoryCustom.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/repository/OrdersRepositoryCustom.java
@@ -2,7 +2,6 @@ package com.fashionmall.order.repository;
 
 import com.fashionmall.common.moduleApi.dto.OrderItemDto;
 import com.fashionmall.common.response.PageInfoResponseDto;
-import com.fashionmall.order.dto.response.OrdersCompleteResponseDto;
 import com.fashionmall.order.dto.response.OrdersDetailResponseDto;
 import com.fashionmall.order.dto.response.OrdersResponseDto;
 import org.springframework.data.domain.Pageable;
@@ -10,8 +9,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface OrdersRepositoryCustom {
-
-    OrdersCompleteResponseDto findByOrderId(Long orderId);
 
     List<OrderItemDto> findOrderItemsByOrderId(Long orderId);
 

--- a/module-order-service/src/main/java/com/fashionmall/order/repository/OrdersRepositoryImpl.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/repository/OrdersRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.fashionmall.order.repository;
 import com.fashionmall.common.moduleApi.dto.OrderItemDto;
 import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.order.dto.response.OrderItemDetailResponseDto;
-import com.fashionmall.order.dto.response.OrdersCompleteResponseDto;
 import com.fashionmall.order.dto.response.OrdersDetailResponseDto;
 import com.fashionmall.order.dto.response.OrdersResponseDto;
 import com.fashionmall.order.enums.OrderStatus;
@@ -24,18 +23,6 @@ import static com.fashionmall.order.entity.QOrders.orders;
 public class OrdersRepositoryImpl implements OrdersRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
-
-    @Override
-    public OrdersCompleteResponseDto findByOrderId(Long orderId) {
-        return queryFactory
-                .select(Projections.constructor(OrdersCompleteResponseDto.class,
-                        orders.id,
-                        orders.createdAt,
-                        orders.paymentPrice))
-                .from(orders)
-                .where(orders.id.eq(orderId))
-                .fetchOne();
-    }
 
     @Override
     public List<OrderItemDto> findOrderItemsByOrderId(Long orderId) {

--- a/module-order-service/src/main/java/com/fashionmall/order/service/BillingKeyService.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/service/BillingKeyService.java
@@ -1,14 +1,15 @@
 package com.fashionmall.order.service;
 
-import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.order.dto.request.BillingKeyRequestDto;
 import com.fashionmall.order.dto.response.UserBillingKeyResponseDto;
+
+import java.util.List;
 
 public interface BillingKeyService {
 
     Long issueBillingKey(BillingKeyRequestDto billingKeyRequestDto);
 
-    PageInfoResponseDto<UserBillingKeyResponseDto> getUserBillingKeyList(Long userId, int pageNo, int size);
+    List<UserBillingKeyResponseDto> getUserBillingKeyList(Long userId);
 
     Long deleteBillingKey(Long billingKeyId);
 }

--- a/module-order-service/src/main/java/com/fashionmall/order/service/BillingKeyServiceImpl.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/service/BillingKeyServiceImpl.java
@@ -1,6 +1,5 @@
 package com.fashionmall.order.service;
 
-import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.order.dto.request.BillingKeyRequestDto;
 import com.fashionmall.order.dto.response.BillingKeyResponseDto;
 import com.fashionmall.order.dto.response.UserBillingKeyResponseDto;
@@ -9,10 +8,10 @@ import com.fashionmall.order.infra.iamPort.dto.IamPortResponseDto;
 import com.fashionmall.order.infra.iamPort.util.IamPortClient;
 import com.fashionmall.order.repository.BillingKeyRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -48,18 +47,18 @@ public class BillingKeyServiceImpl implements BillingKeyService {
             cardType = "체크카드";
         }
 
+        String cardNumber = maskCardNumber(billingKeyRequestDto.getCardNumber());
 
-        BillingKey billingKey = billingKeyRequestDto.toEntity(cardName, cardType, customerUid);
+        BillingKey billingKey = billingKeyRequestDto.toEntity(cardNumber, cardName, cardType, customerUid);
         billingKeyRepository.save(billingKey);
 
         return billingKey.getId();
     }
 
     @Override
-    public PageInfoResponseDto<UserBillingKeyResponseDto> getUserBillingKeyList(Long userId, int pageNo, int size) {
-        PageRequest pageRequest = PageRequest.of(pageNo - 1, size);
+    public List<UserBillingKeyResponseDto> getUserBillingKeyList(Long userId) {
 
-        return billingKeyRepository.findBillingKeyByUserId(userId, pageRequest);
+        return billingKeyRepository.findBillingKeyByUserId(userId);
     }
 
     @Transactional
@@ -73,5 +72,11 @@ public class BillingKeyServiceImpl implements BillingKeyService {
         billingKeyRepository.deleteById(billingKeyId);
 
         return billingKeyId;
+    }
+
+    private String maskCardNumber(String cardNumber) {
+        int length = cardNumber.length();
+        String last4Digits = cardNumber.substring(length - 4);
+        return "*".repeat(length - 4) + last4Digits;
     }
 }

--- a/module-order-service/src/main/java/com/fashionmall/order/service/OrdersService.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/service/OrdersService.java
@@ -2,13 +2,12 @@ package com.fashionmall.order.service;
 
 import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.order.dto.request.OrderPaymentRequestDto;
-import com.fashionmall.order.dto.response.OrdersCompleteResponseDto;
 import com.fashionmall.order.dto.response.OrdersDetailResponseDto;
 import com.fashionmall.order.dto.response.OrdersResponseDto;
 
 public interface OrdersService {
 
-    OrdersCompleteResponseDto createAndPaymentOrder(OrderPaymentRequestDto orderPaymentRequestDto);
+    Long createAndPaymentOrder(OrderPaymentRequestDto orderPaymentRequestDto);
 
     PageInfoResponseDto<OrdersResponseDto> getOrders(Long userId, int pageNo, int size);
 

--- a/module-order-service/src/main/java/com/fashionmall/order/service/OrdersServiceImpl.java
+++ b/module-order-service/src/main/java/com/fashionmall/order/service/OrdersServiceImpl.java
@@ -9,7 +9,10 @@ import com.fashionmall.common.moduleApi.util.ModuleApiUtil;
 import com.fashionmall.common.response.PageInfoResponseDto;
 import com.fashionmall.order.dto.request.OrderItemRequestDto;
 import com.fashionmall.order.dto.request.OrderPaymentRequestDto;
-import com.fashionmall.order.dto.response.*;
+import com.fashionmall.order.dto.response.OrderItemDetailResponseDto;
+import com.fashionmall.order.dto.response.OrdersDetailResponseDto;
+import com.fashionmall.order.dto.response.OrdersResponseDto;
+import com.fashionmall.order.dto.response.PaymentResponseDto;
 import com.fashionmall.order.entity.BillingKey;
 import com.fashionmall.order.entity.Orders;
 import com.fashionmall.order.entity.Payment;
@@ -48,7 +51,7 @@ public class OrdersServiceImpl implements OrdersService {
 
     @Transactional
     @Override
-    public OrdersCompleteResponseDto createAndPaymentOrder(OrderPaymentRequestDto orderPaymentRequestDto) {
+    public Long createAndPaymentOrder(OrderPaymentRequestDto orderPaymentRequestDto) {
         //<<주문>>
         Long userId = orderPaymentRequestDto.getUserId();
         Long couponId = orderPaymentRequestDto.getCouponId();
@@ -182,7 +185,7 @@ public class OrdersServiceImpl implements OrdersService {
         //재고차감
         eventPublisher.publishEvent(new StockDeductEvent(order.getId()));
 
-        return ordersRepository.findByOrderId(order.getId());
+        return order.getId();
     }
 
     @Override
@@ -215,6 +218,7 @@ public class OrdersServiceImpl implements OrdersService {
         return ordersDetails;
     }
 
+    @Transactional
     @Override
     public Long cancelOrder(Long userId, Long orderId) {
 


### PR DESCRIPTION
## 📝작업 내용

- 주문 쿠폰 목록 조회 API : 엔드포인트 /api/coupon/getCoupon로 변경
- 결제수단 목록 조회 API (마이페이지) : 페이징 처리 제거, List로 응답처리, 응답값에 뒤에 4자리 제외하고 마스킹처리한 카드번호 추가. cardNumber
- 주문하기 API : Long로 타입 수정 (orderId만 전달)
- 다운로드가능쿠폰목록 API : 페이징처리 제거. List 처리, 응답값에 couponId 추가하기

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 🔗참고 링크(선택)

## ⏰기한

- 2024-10-29